### PR TITLE
Add "sopelshh", for multiplexing Bucket & Sopel

### DIFF
--- a/plugin.sopelshh.pl
+++ b/plugin.sopelshh.pl
@@ -1,0 +1,57 @@
+# BUCKET PLUGIN
+
+use BucketBase qw/config Log/;
+use Config::Tiny;
+
+our $prefix = '';
+
+sub signals {
+    return (qw/empty_lookup/)
+}
+
+sub settings {
+    return (
+        sopel_config => [ f => '/var/lib/sopel/default.cfg' ],
+    );
+}
+
+sub start {
+    &load_config();
+}
+
+sub commands {
+    return (
+        {
+            label     => 'refresh sopel config',
+            addressed => 1,
+            operator  => 1,
+            editable  => 0,
+            re        => qr/^refresh sopel config$/i,
+            callback  => \&load_config
+        },
+    );
+}
+
+sub route {
+    my ( $package, $sig, $data ) = @_;
+
+    return 0 if $::prefix eq '';
+
+    if ( $data->{msg} =~ /^(?:$::prefix)/ ) {
+        return -1;
+    }
+
+    return 0;
+}
+
+sub load_config {
+    my $config = Config::Tiny->read( &config('sopel_config') );
+
+    if ( exists $config->{core}->{prefix} ) {
+        $::prefix = $config->{core}->{prefix};
+    } else {
+        $::prefix = '\.';
+    }
+
+    &Log( "Loaded Sopel prefix: '$::prefix'" );
+}


### PR DESCRIPTION
Sometimes the best way to get all the functionality you want in an IRC bot is to just run two (or more) bots behind the same nick using a bouncer. Bucket sometimes responds to the Sopel bot's commands, which
can be confusing, but this plugin tells Bucket to stay quiet unless the command exactly matches a factoid.