### PR TITLE
Add "but fuck" plugin (requested)

### DIFF
--- a/plugin.butfuck.pl
+++ b/plugin.butfuck.pl
@@ -1,0 +1,35 @@
+# BUCKET PLUGIN
+
+# Inspired by a request (of sorts) on IRC:
+# <flameboi> "but fuck" in messages should be replaced by "butt fuck" like
+#            with ex* and sex*
+
+use BucketBase qw/say config talking/;
+
+sub signals {
+    return (qw/on_public/);
+}
+
+sub settings {
+    return (
+        butfuck_chance => [ p => 15 ],
+    );
+}
+
+sub route {
+    my ( $package, $sig, $data ) = @_;
+
+    if (    $data->{msg} =~ /\bbut fuck(?:\b|$)/i
+        and rand(100) < &config("butfuck_chance")
+        and &talking( $data->{chl} ) == -1 )
+    {
+        my $doctored = $data->{msg};
+        $doctored =~ s/(but) fuck/$1t fuck/i;
+        &say( $data->{chl} => $doctored );
+
+        # don't process any further
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Cloned and slightly modified from the "discord" plugin in this repo.

The inspiration, from my IRC channel:

```chat
<flameboi> "but fuck" in messages should be replaced by "butt fuck"
           like with ex* and sex*
```